### PR TITLE
Add global configuration for default/global coffeelint.json config path

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 module.exports =
   configDefaults:
     coffeelintExecutablePath: path.join __dirname, '..', 'node_modules', 'coffeelint', 'bin'
+    coffeelintConfigPath: null
 
   activate: ->
     console.log 'activate linter-coffelint'

--- a/lib/linter-coffeelint.coffee
+++ b/lib/linter-coffeelint.coffee
@@ -23,12 +23,18 @@ class LinterCoffeelint extends Linter
 
   isNodeExecutable: yes
 
+  configPath: null
+
   constructor: (editor) ->
     super(editor)
 
-    config = findFile(@cwd, ['coffeelint.json'])
-    if config
-      @cmd += " -f #{config}"
+    atom.config.observe 'linter-coffeelint.coffeelintConfigPath', =>
+      @configPath = atom.config.get 'linter-coffeelint.coffeelintConfigPath'
+
+    if configPathLocal = findFile(@cwd, ['coffeelint.json'])
+      @cmd += " -f #{configPathLocal}"
+    else if @configPath
+      @cmd += " -f #{@configPath}"
 
     atom.config.observe 'linter-coffeelint.coffeelintExecutablePath', =>
       @executablePath = atom.config.get 'linter-coffeelint.coffeelintExecutablePath'
@@ -38,5 +44,6 @@ class LinterCoffeelint extends Linter
 
   destroy: ->
     atom.config.unobserve 'linter-coffeelint.coffeelintExecutablePath'
+    atom.config.unobserve 'linter-coffeelint.coffeelintConfigPath'
 
 module.exports = LinterCoffeelint


### PR DESCRIPTION
This adds an Atom configuration (`linter-coffeelint.coffeelintConfigPath`) for setting a path to a default/global `coffeelint.json` configuration.
