### PR TITLE
Require and use CoffeeLint directly instead of the CLI

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,9 +1,13 @@
 path = require 'path'
 
 module.exports =
-  configDefaults:
-    coffeelintExecutablePath: path.join __dirname, '..', 'node_modules', 'coffeelint', 'bin'
-    coffeelintConfigPath: null
+  # Your configuration belongs in your project, not your editor.
+  # https://github.com/clutchski/coffeelint/blob/master/doc/user.md
+  #
+  # If you include coffeelint in your project's dev dependencies it will use
+  # that version. This is the same behavior the coffeelint commandline gives
+  # you.
+  configDefaults: {}
 
   activate: ->
     console.log 'activate linter-coffeelint'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "coffeelint": "~1.5.2"
+    "coffeelint": "^1.9.1",
+    "resolve": "^1.1.5"
   }
 }


### PR DESCRIPTION
Fixes #17 
Fixes #11 
Closes #18 

This PR should bring linter-coffeelint in line with the same behavior you get out of running the CLI by hand. It will pick up your project-specific configs and project-specific version of CoffeeLint.

There was an issue I had to fix in CoffeeLint https://github.com/clutchski/coffeelint/pull/383 to make it compatible. I pushed that out as v1.9.1 tonight.