### PR TITLE
Add linter-plus compatibility

### DIFF
--- a/lib/core.coffee
+++ b/lib/core.coffee
@@ -1,0 +1,91 @@
+# I can't just map over parseInt because it needs the 2nd parameter and map
+# passes the current index as the 2nd parameter
+toInt = (str) -> parseInt(str, 10)
+
+module.exports =
+
+  # The syntax that the linter handles. May be a string or
+  # list/tuple of strings. Names should be all lowercase.
+  #
+  # If you have the react plugin it switches source.coffee to source.coffee.jsx
+  # even if you aren't actually using jsx in that file.
+  scopes: ['source.coffee', 'source.litcoffee', 'source.coffee.jsx']
+
+  _resolveCoffeeLint: (filePath) ->
+    try
+      return path.dirname(resolve('coffeelint/package.json', {
+        basedir: path.dirname(filePath)
+      }))
+    return 'coffeelint'
+
+  configImportsModules: (config) ->
+    return true for ruleName, rconfig of config when rconfig.module?
+    return userConfig?.coffeelint?.transforms?
+
+  canImportModules: (coffeelint) ->
+    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
+
+    if major > 1
+      return true
+    if major is 1 and minor > 9
+      return true
+    if major is 1 and minor is 9 and patch >= 5
+      return true
+    false
+
+  isCompatibleWithAtom: (coffeelint) ->
+    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
+
+    if major > 1
+      return true
+    if major is 1 and minor > 9
+      return true
+    if major is 1 and minor is 9 and patch >= 1
+      return true
+    false
+
+  lint: (filePath, origPath, source, scopeName) ->
+    isLiterate = scopeName is 'source.litcoffee'
+    showUpgradeError = false
+
+    coffeeLintPath = @_resolveCoffeeLint(origPath)
+    coffeelint = require(coffeeLintPath)
+
+    # Versions before 1.9.1 don't work with atom because of an assumption that
+    # if window is defined, then it must be running in a browser. Atom breaks
+    # this assumption, so CoffeeLint < 1.9.1 will fail to find CoffeeScript.
+    # See https://github.com/clutchski/coffeelint/pull/383
+    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
+    if not @isCompatibleWithAtom(coffeelint)
+      coffeeLintPath = 'coffeelint'
+      coffeelint = require(coffeeLintPath)
+      showUpgradeError = true
+
+    configFinder = require("#{coffeeLintPath}/lib/configfinder")
+
+    result = []
+    try
+      config = configFinder.getConfig(origPath)
+      if @configImportsModules(config) and not @canImportModules(coffeelint)
+        showUpgradeError = true
+      else
+        result = coffeelint.lint(source, config, isLiterate)
+    catch e
+      console.log(e.message)
+      console.log(e.stack)
+      result.push({
+        lineNumber: 1
+        level: 'error'
+        message: "CoffeeLint crashed, see console for error details."
+        rule: 'none'
+      })
+
+    if showUpgradeError
+      result = [{
+        lineNumber: 1
+        level: 'error'
+        message: "http://git.io/local_upgrade upgrade your project's CoffeeLint"
+        rule: 'none'
+      }]
+
+    return result

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -11,3 +11,6 @@ module.exports =
 
   activate: ->
     console.log 'activate linter-coffeelint'
+
+  provideLinter: ->
+    return require('./plus-linter.coffee')

--- a/lib/linter-coffeelint.coffee
+++ b/lib/linter-coffeelint.coffee
@@ -1,118 +1,38 @@
-linterPath = atom.packages.getLoadedPackage('linter').path
-Linter = require "#{linterPath}/lib/linter"
-path = require('path')
-resolve = require('resolve').sync
+linterPackage = atom.packages.getLoadedPackage('linter')
 
-# I can't just map over parseInt because it needs the 2nd parameter and map
-# passes the current index as the 2nd parameter
-toInt = (str) -> parseInt(str, 10)
+if linterPackage
+  Core = require('./core.coffee')
+  Linter = require "#{linterPackage.path}/lib/linter"
+  path = require('path')
+  resolve = require('resolve').sync
 
-class LinterCoffeelint extends Linter
-  # The syntax that the linter handles. May be a string or
-  # list/tuple of strings. Names should be all lowercase.
-  #
-  # If you have the react plugin it switches source.coffee to source.coffee.jsx
-  # even if you aren't actually using jsx in that file.
-  @syntax: ['source.coffee', 'source.litcoffee', 'source.coffee.jsx']
 
-  linterName: 'coffeelint'
+  class LinterCoffeelint extends Linter
+    @syntax: Core.scopes
 
-  _resolveCoffeeLint: (filePath) ->
-    try
-      return path.dirname(resolve('coffeelint/package.json', {
-        basedir: path.dirname(filePath)
-      }))
-    return 'coffeelint'
+    linterName: 'coffeelint'
 
-  configImportsModules: (config) ->
-    return true for ruleName, rconfig of config when rconfig.module?
-    return userConfig?.coffeelint?.transforms?
+    lintFile: (filePath, callback) =>
+      filename = path.basename filePath
+      origPath = path.join @cwd, filename
+      source = @editor.getText()
+      scopeName = @editor.getGrammar().scopeName
 
-  canImportModules: (coffeelint) ->
-    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
+      callback(Core.lint(filePath, origPath, source, scopeName).map(@transform))
 
-    if major > 1
-      return true
-    if major is 1 and minor > 9
-      return true
-    if major is 1 and minor is 9 and patch >= 5
-      return true
-    false
+    transform: (m) =>
+      message = m.message
+      if m.context
+        message += ". #{m.context}"
 
-  isCompatibleWithAtom: (coffeelint) ->
-    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
+      return @createMessage {
+        line: m.lineNumber,
+        # None of the rules currently return a column, but they may in the
+        # future.
+        col: m.column,
+        error: m.level is 'error'
+        warning: m.level is 'warn'
+        message: "#{message}. (#{m.rule})"
+      }
 
-    if major > 1
-      return true
-    if major is 1 and minor > 9
-      return true
-    if major is 1 and minor is 9 and patch >= 1
-      return true
-    false
-
-  lintFile: (filePath, callback) ->
-    filename = path.basename filePath
-    origPath = path.join @cwd, filename
-    showUpgradeError = false
-
-    coffeeLintPath = @_resolveCoffeeLint(origPath)
-    coffeelint = require(coffeeLintPath)
-
-    # Versions before 1.9.1 don't work with atom because of an assumption that
-    # if window is defined, then it must be running in a browser. Atom breaks
-    # this assumption, so CoffeeLint < 1.9.1 will fail to find CoffeeScript.
-    # See https://github.com/clutchski/coffeelint/pull/383
-    [major, minor, patch] = coffeelint.VERSION.split('.').map(toInt)
-    if not @isCompatibleWithAtom(coffeelint)
-      coffeeLintPath = 'coffeelint'
-      coffeelint = require(coffeeLintPath)
-      showUpgradeError = true
-
-    configFinder = require("#{coffeeLintPath}/lib/configfinder")
-
-    isLiterate = @editor.getGrammar().scopeName is 'source.litcoffee'
-    source = @editor.getText()
-
-    try
-      config = configFinder.getConfig(origPath)
-      console.log('using coffeelint', coffeelint.VERSION,
-        @configImportsModules(config), @canImportModules(coffeelint) )
-      if @configImportsModules(config) and not @canImportModules(coffeelint)
-        showUpgradeError = true
-      else
-        result = coffeelint.lint(source, config, isLiterate)
-    catch e
-      result = []
-      console.log(e.message)
-      console.log(e.stack)
-      result.push({
-        lineNumber: 1
-        level: 'error'
-        message: "CoffeeLint crashed, see console for error details."
-        rule: 'none'
-      })
-
-    if showUpgradeError
-      result = [{
-        lineNumber: 1
-        level: 'error'
-        message: "http://git.io/local_upgrade upgrade your project's CoffeeLint"
-        rule: 'none'
-      }]
-
-    callback(result.map(@transform))
-
-  transform: (m) =>
-    message = m.message
-    if m.context
-      message += ". #{m.context}"
-    @createMessage {
-      line: m.lineNumber,
-      # None of the rules currently return a column, but they may in the future.
-      col: m.column,
-      error: m.level is 'error'
-      warning: m.level is 'warn'
-      message: "#{message}. (#{m.rule})"
-    }
-
-module.exports = LinterCoffeelint
+  module.exports = LinterCoffeelint

--- a/lib/plus-linter.coffee
+++ b/lib/plus-linter.coffee
@@ -1,0 +1,42 @@
+Core = require('./core.coffee')
+path = require('path')
+
+module.exports = new class # This only needs to be a class to bind lint()
+
+  scopes: Core.scopes
+  lintOnFly: true
+
+  # coffeelint: disable=no_unnecessary_fat_arrows
+  # The fat arrow here is necessary
+  lint: (TextEditor, TextBuffer, {Error}) =>
+  # coffeelint: enable=no_unnecessary_fat_arrows
+    filePath = TextEditor.getPath()
+    if filePath
+      origPath = if filePath then path.dirname filePath else ''
+      source = TextEditor.getText()
+
+      window.lastTextEditor = TextEditor
+      scopeName = TextEditor.getGrammar().scopeName
+
+
+      transform = ({level, message, rule, lineNumber, context, column}) ->
+        message = "#{message}. #{context}" if context
+        message = "#{message}. (#{rule})";
+
+        # Calculate range to make the error whole line
+        # without the indentation at begining of line
+        indentLevel = TextEditor.indentationForBufferRow(lineNumber - 1)
+
+        startCol = (TextEditor.getTabLength() * indentLevel) + 1
+        endCol = TextBuffer.lineLengthForRow(lineNumber - 1)
+
+        range = [[lineNumber, startCol], [lineNumber, endCol]]
+
+        return {
+          Type: if level is 'error' then 'Error' else 'Warning'
+          Message: message
+          File: filePath
+          Position: range
+        }
+
+      return Core.lint(filePath, origPath, source, scopeName).map(transform)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
   "engines": {
     "atom": ">0.50.0"
   },
+  "providedServices": {
+    "linter-plus": {
+      "versions": {
+        "0.1.0": "provideLinter"
+      }
+    }
+  },
   "dependencies": {
     "coffeelint": "^1.9.7",
     "resolve": "^1.1.5"


### PR DESCRIPTION
With this PR linter-coffeelint works with [AtomLinter/linter](https://github.com/AtomLinter/linter) and [AtomLinter/linter-plus](https://github.com/AtomLinter/linter-plus).

Fixes https://github.com/iam4x/linter-plus-coffeelint/issues/2

This should replace the linter-plus-coffeelint repo.