### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "activationHooks": ["language-coffee-script:grammar-used"],
   "package-deps": [
     "linter"
   ],

--- a/spec/linter-coffeelint-spec.js
+++ b/spec/linter-coffeelint-spec.js
@@ -9,12 +9,22 @@ const lint = require('../lib/init.coffee').provideLinter().lint;
 describe('The CoffeeLint provider for Linter', () => {
   describe('works with CoffeeScript files and', () => {
     beforeEach(() => {
+      // This whole beforeEach function is inspired by:
+      // https://github.com/AtomLinter/linter-jscs/pull/295/files
+      //
+      // See also:
+      // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+      const activationPromise =
+        atom.packages.activatePackage('linter-coffeelint');
+
       waitsForPromise(() =>
-        Promise.all([
-          atom.packages.activatePackage('linter-coffeelint'),
-          atom.packages.activatePackage('language-coffee-script'),
-        ])
-      );
+        atom.packages.activatePackage('language-coffee-script'));
+
+      waitsForPromise(() =>
+        atom.workspace.open(validPath));
+
+      atom.packages.triggerDeferredActivationHooks();
+      waitsForPromise(() => activationPromise);
     });
 
     it('finds nothing wrong with a valid file', () => {

--- a/spec/linter-coffeelint-spec.js
+++ b/spec/linter-coffeelint-spec.js
@@ -9,19 +9,14 @@ const lint = require('../lib/init.coffee').provideLinter().lint;
 describe('The CoffeeLint provider for Linter', () => {
   describe('works with CoffeeScript files and', () => {
     beforeEach(() => {
-      // This whole beforeEach function is inspired by:
-      // https://github.com/AtomLinter/linter-jscs/pull/295/files
-      //
-      // See also:
-      // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+      // Info about this beforeEach() implementation:
+      // https://github.com/AtomLinter/Meta/issues/15
       const activationPromise =
         atom.packages.activatePackage('linter-coffeelint');
 
       waitsForPromise(() =>
-        atom.packages.activatePackage('language-coffee-script'));
-
-      waitsForPromise(() =>
-        atom.workspace.open(validPath));
+        atom.packages.activatePackage('language-coffee-script').then(() =>
+          atom.workspace.open(validPath)));
 
       atom.packages.triggerDeferredActivationHooks();
       waitsForPromise(() => activationPromise);


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any CoffeeScript files open.

With this change in place, we postpone activation until the Atom
CoffeeScript grammar's first use.

This improves startup time of my Atom by about 29ms, thus fixing one of
the top startup time offenders according to TimeCop.

For some frame of reference, I have 87 packages installed, and Timecop
lists all packages with startup times above 5ms.