### PR TITLE
Add language-iced-coffee-script to activationHooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "atom": ">=1.7.0 <2.0.0"
   },
   "activationHooks": [
-    "language-coffee-script:grammar-used"
+    "language-coffee-script:grammar-used",
+    "language-iced-coffee-script:grammar-used"
   ],
   "package-deps": [
     "linter:2.0.0"


### PR DESCRIPTION
Adds `language-iced-coffee-script` to the list of languages that will activate this package.

Fixes https://github.com/AtomLinter/linter-coffeelint/issues/89.