### PR TITLE
Support .coffeelintignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.0",
     "coffeelint": "^1.16.0",
+    "ignore": "^3.3.3",
     "resolve": "^1.4.0",
     "semver": "^5.4.1"
   },


### PR DESCRIPTION
Add support for processing .coffeelintignore files like CoffeeLint does.

Fixes https://github.com/AtomLinter/linter-coffeelint/issues/50.