### PR TITLE
Default Config & Disable If No Project Config settings

### DIFF
--- a/spec/fixtures/default_config/coffeelint.json
+++ b/spec/fixtures/default_config/coffeelint.json
@@ -1,0 +1,6 @@
+{
+  "max_line_length": {
+    "value": 10,
+    "level": "warn"
+  }
+}

--- a/spec/fixtures/no_config/no_config.coffee
+++ b/spec/fixtures/no_config/no_config.coffee
@@ -1,0 +1,2 @@
+# This is a very long line that will trigger max_line_length if the default config is used
+a = 1

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,13 @@ const loadDeps = () => {
 module.exports = {
   config: {
     defaultConfig: {
-      title: 'Default Config Path',
+      title: 'coffeelint.json Path',
+      description: "It will only be used when there's no config file in project",
       type: 'string',
-      default: atom.getConfigDirPath(),
+      default: '',
     },
     disableIfNoConfig: {
-      title: 'Disable If No Project Config File Is Found',
+      title: 'Disable when no coffeelint config is found (in package.json or coffeelint.json)',
       type: 'boolean',
       default: false,
     },
@@ -79,8 +80,7 @@ module.exports = {
           cursor.getScopeDescriptor().getScopesArray().some(scope =>
             scope === 'source.litcoffee'));
 
-        const defaultConfig = atom.config.get('linter-coffeelint.defaultConfig');
-        const disableIfNoConfig = atom.config.get('linter-coffeelint.disableIfNoConfig');
+        const linterConfig = atom.config.get('linter-coffeelint');
 
         const transform = ({
           level, message, rule, lineNumber, context,
@@ -109,8 +109,7 @@ module.exports = {
             filePath,
             source,
             isLiterate,
-            defaultConfig,
-            disableIfNoConfig,
+            linterConfig,
             (results) => {
               this.workers.delete(task);
               try {

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,7 +29,7 @@ const configImportsModules = (config) => {
     Object.prototype.hasOwnProperty.call(config[ruleName], 'module'));
 };
 
-module.exports = (filePath, source, isLiterate) => {
+module.exports = (filePath, source, isLiterate, defaultConfig, disableIfNoConfig) => {
   const fileDir = path.dirname(filePath);
   process.chdir(fileDir);
 
@@ -76,6 +76,18 @@ module.exports = (filePath, source, isLiterate) => {
       /* eslint-enable import/no-dynamic-require */
       config = configFinder.getConfig(filePath);
       showUpgradeError = true;
+    }
+  }
+
+  if (!config) {
+    if (disableIfNoConfig) {
+      return [];
+    } else if (defaultConfig) {
+      let configFile = defaultConfig;
+      if (!configFile.endsWith('coffeelint.json')) {
+        configFile = path.join(configFile, 'coffeelint.json');
+      }
+      config = configFinder.getConfig(configFile);
     }
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,7 +29,7 @@ const configImportsModules = (config) => {
     Object.prototype.hasOwnProperty.call(config[ruleName], 'module'));
 };
 
-module.exports = (filePath, source, isLiterate, defaultConfig, disableIfNoConfig) => {
+module.exports = (filePath, source, isLiterate, linterConfig) => {
   const fileDir = path.dirname(filePath);
   process.chdir(fileDir);
 
@@ -80,10 +80,10 @@ module.exports = (filePath, source, isLiterate, defaultConfig, disableIfNoConfig
   }
 
   if (!config) {
-    if (disableIfNoConfig) {
+    if (linterConfig.disableIfNoConfig) {
       return [];
-    } else if (defaultConfig) {
-      let configFile = defaultConfig;
+    } else if (linterConfig.defaultConfig) {
+      let configFile = linterConfig.defaultConfig;
       if (!configFile.endsWith('coffeelint.json')) {
         configFile = path.join(configFile, 'coffeelint.json');
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/97994/35550074-60ff423e-054e-11e8-807a-a2c5fe7cc87c.png)

Adds settings to use a default config if no project config is found. The default setting is `~/.atom` like other linters.

I also added a checkbox to disable coffeelint if no project config is found.

closes #98 