### PR TITLE
use personal access token for release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm ci
       - name: Release 🎉
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ATOM_ACCESS_TOKEN: ${{ secrets.ATOM_ACCESS_TOKEN }}
         run: npx semantic-release
 


### PR DESCRIPTION
Looks like the `GITHUB_TOKEN` in GitHub actions doesn't have access to push releases to the master branch. We will have to use a personal access token like before.

@Arcanemagus You can add the token to `GH_TOKEN` and the release should work with this PR

https://github.com/AtomLinter/linter-coffeelint/runs/418460239?check_suite_focus=true#step:6:108