### PR TITLE
Replace default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,8 @@ jobs:
         run: npm ci
       - name: Release 🎉
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Override the default Actions token with a private token
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           ATOM_ACCESS_TOKEN: ${{ secrets.ATOM_ACCESS_TOKEN }}
         run: npx semantic-release
 


### PR DESCRIPTION
The `GITHUB_TOKEN` provided by GitHub Actions only has standard user push rights to the repository. Unfortunately if branch protections are enabled you can't bypass them in a workflow normally, so you must use a personal token of an administrator. This overrides the default `GITHUB_TOKEN` value with a secret value named `GH_TOKEN`.

Note: This replacement _only_ happens for the release job, so PR's from external repositories should still be using the default `GITHUB_TOKEN` if needed.

Reference to a previous attempt: https://github.com/AtomLinter/linter-coffeelint/pull/260